### PR TITLE
AS-39 | UI fixes

### DIFF
--- a/src/lib/App/styleProvider.jsx
+++ b/src/lib/App/styleProvider.jsx
@@ -30,7 +30,9 @@ const StyleProvider = ({
     Menu: {
       itemHoverColor: themeToken.sideMenuItemActive,
       darkItemHoverColor: themeToken.sideMenuItemActive,
-      itemDisabledColor: themeToken.sideMenuItemDefault
+      itemSelectedColor: themeToken.sideMenuItemActive,
+      itemDisabledColor: themeToken.sideMenuItemDefault,
+      itemHoverBg: 'transparent'
     },
     Radio: {
       buttonColor: themeToken.sideMenuItemDefault,

--- a/src/lib/components/Layout/SideMenu/index.jsx
+++ b/src/lib/components/Layout/SideMenu/index.jsx
@@ -47,7 +47,6 @@ const SideMenu = ({ sidebarItems, onSideMenuSelect, pathname = '', children }) =
         defaultOpenKeys={defaultMenuKeys?.defaultOpenKeys}
         defaultSelectedKeys={[defaultMenuKeys?.defaultSelectedKey]}
         selectedKeys={[defaultMenuKeys?.defaultSelectedKey]}
-        theme="dark"
         mode="inline"
         items={sidebarMenuItems}
         onSelect={onSideMenuSelect}

--- a/src/lib/components/Layout/SideMenu/index.styled.js
+++ b/src/lib/components/Layout/SideMenu/index.styled.js
@@ -20,6 +20,10 @@ export const SideMenuContainer = styled(Layout.Sider)`
   & .ant-menu-item:active {
     background: transparent !important;
   }
+
+  & .ant-menu-submenu-selected > .ant-menu-submenu-title {
+    color: ${({ theme }) => theme.sideMenuItemOpen};
+  }
 `
 
 export const StyledLink = styled(Typography.Link)`

--- a/src/lib/components/PageContainer/index.styled.js
+++ b/src/lib/components/PageContainer/index.styled.js
@@ -8,6 +8,7 @@ import { COLORS } from '../../constants'
 export const Header = styled(Card)`
   border-radius: 0 0 6px 6px;
   margin-bottom: 8px;
+  background: ${COLORS.white} !important;
 
   .ant-card-body {
     padding: 12px 40px;

--- a/src/lib/components/TopNav/ClientsDropdown/index.styled.js
+++ b/src/lib/components/TopNav/ClientsDropdown/index.styled.js
@@ -17,7 +17,7 @@ export const StyledClientsMenu = styled(Menu)`
   .ant-menu-submenu-selected:not(.ant-menu-submenu-open) {
     &,
     & * {
-      color: ${COLORS.white};
+      color: ${({ theme }) => theme.sideMenuItemDefault};
     }
   }
 

--- a/src/lib/constants/componentsConfig.js
+++ b/src/lib/constants/componentsConfig.js
@@ -2,7 +2,9 @@ import { COLORS } from './index'
 
 const components = {
   Menu: {
-    itemDisabledColor: COLORS.white
+    itemDisabledColor: COLORS.white,
+    itemHoverColor: COLORS.white,
+    itemHoverBg: 'transparent'
   }
 }
 


### PR DESCRIPTION
task: https://sosup.atlassian.net/browse/AS-39

Fixed:
* Side menu item colors (active parent item when submenu closed)
* Client select color (after choosing client)
* Page container background (there was a bug, that reproduces **sometimes**, see the screenshots. Sometimes the page container has the same class name as side-nav and the background changes to the dark one)

![Screenshot_2](https://github.com/IvanSakhman/stage_ui/assets/67602323/ed3e3850-d46c-47f5-9dae-b73e57a620c5)
![Screenshot_1](https://github.com/IvanSakhman/stage_ui/assets/67602323/389f2527-f756-4fec-8e92-0ecd3f3af2d8)
